### PR TITLE
Change to downgrade Elasticache client to 1.2.0

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "com.amazonaws", artifactId = "elasticache-java-cluster-client" } ]

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 val catsEffectVersion = "3.6.1"
 val circeVersion = "0.14.12"
-val elasticacheJavaClusterClientVersion = "1.2.2"
+val elasticacheJavaClusterClientVersion = "1.2.0"
 val munitCatsEffectVersion = "2.1.0"
 val munitScalaCheckVersion = "1.1.0"
 val scala213Version = "2.13.16"


### PR DESCRIPTION
The newer versions seem to have issues with node auto-discovery and custom Memcached addresses. We've never released a version with Elasticache client > 1.2.0, so this downgrade is straightforward.